### PR TITLE
updated docs link and fixed branch for scand-manager

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "conformance-scan/kubernetes-integration"]
 	path = conformance-scan/kubernetes-integration
 	url = https://github.com/42Crunch/scand-manager
+	branch = master

--- a/conformance-scan/aws-batch-deployment/README.md
+++ b/conformance-scan/aws-batch-deployment/README.md
@@ -77,7 +77,7 @@ The JSON file looks like this.
 
 ```
 
-You can obtain the on-premises scan token following these instructions: https://docs-preview.42crunch.com/latest/content/tasks/scan_api_conformance.htm#scrollNav-4
+You can obtain the on-premises scan token following these instructions: [Conformance Scan Docs](https://docs.42crunch.com/latest/content/tasks/scan_api_conformance.htm#scrollNav-4)
 
 If you deploy the job definition multiple times, you need to indicate the revision number, like this : 
 


### PR DESCRIPTION
The link to scand-manager is very old and modified the docs-preview link to point to the public docs